### PR TITLE
Firefox Compatibility, Firefox Selector

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="sticky-header z-50 flex w-full justify-between bg-white bg-opacity-40 py-4 px-6 text-3xl font-semibold shadow-md backdrop-blur-md dark:bg-gray-900 dark:bg-opacity-50"
+    class="sticky-header z-50 flex w-full justify-between bg-white bg-opacity-40 py-4 px-6 text-3xl font-semibold shadow-md backdrop-blur-md firefox:bg-opacity-70 dark:bg-gray-900 dark:bg-opacity-50"
   >
     <div>
       <h1>cshighschoolers</h1>
@@ -85,7 +85,7 @@
   });
 
   const scrollYPos = ref(0);
-  const scrollPoints = ref<{ [key: number]: string; }>({});
+  const scrollPoints = ref<{ [key: number]: string }>({});
 
   const selected = computed(() => {
     let scrollPoint = Object.keys(scrollPoints.value)

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -39,7 +39,6 @@
       </div>
     </div>
     <div class="flex flex-grow flex-col justify-end pb-8">
-      <h2 class="pb-2 text-lg">Scroll down for more info</h2>
       <fa-icon class="animate-bounce text-4xl" :icon="['fa', 'angles-down']" />
     </div>
   </div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -9,7 +9,7 @@
     <div class="flex w-full flex-col items-center pl-4 pr-4">
       <h1 class="pb-4 text-5xl">cshighschoolers</h1>
       <h1 class="pb-6 text-3xl">
-        The <span class="">greatest</span> community of highschool programmers
+        The greatest community of highschool programmers
       </h1>
       <div
         class="flex w-full flex-col rounded-lg bg-white bg-opacity-50 p-5 dark:bg-gray-900 sm:w-min"
@@ -45,7 +45,7 @@
   <div class="px-4">
     <div id="about-us-section" class="mb-16 flex flex-col items-center">
       <h2
-        class="pb-4 text-4xl font-bold underline decoration-red-500 decoration-4 underline-offset-1"
+        class="pb-4 text-4xl font-bold underline decoration-red-500 decoration-4 underline-offset-1 firefox:underline-offset-2"
       >
         About us
       </h2>
@@ -65,7 +65,7 @@
 
     <div id="events-section" class="mb-16 flex flex-col items-center">
       <h2
-        class="pb-4 text-4xl font-bold underline decoration-orange-500 decoration-4 underline-offset-1"
+        class="pb-4 text-4xl font-bold underline decoration-orange-500 decoration-4 underline-offset-1 firefox:underline-offset-2"
       >
         Events
       </h2>
@@ -99,7 +99,7 @@
 
     <div id="domains-section" class="mb-16 flex flex-col items-center">
       <h2
-        class="pb-2 text-4xl font-bold underline decoration-green-500 decoration-4 underline-offset-1"
+        class="pb-2 text-4xl font-bold underline decoration-green-500 decoration-4 underline-offset-1 firefox:underline-offset-2"
       >
         Free Domains
       </h2>
@@ -151,6 +151,7 @@
           "nuke",
           "frityet",
           "cdev",
+          "beever",
         ],
         currentDomainExampleIndex: 0,
       };

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -39,6 +39,7 @@
       </div>
     </div>
     <div class="flex flex-grow flex-col justify-end pb-8">
+      <h2 class="pb-2 text-lg">Scroll down for more info</h2>
       <fa-icon class="animate-bounce text-4xl" :icon="['fa', 'angles-down']" />
     </div>
   </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 const colors = require("tailwindcss/colors");
 const glowPlugin = require("./tailwind_plugins_src/glow");
+const firefoxSelector = require("./tailwind_plugins_src/firefoxSelector");
 
 module.exports = {
   darkMode: "class",
@@ -24,5 +25,5 @@ module.exports = {
       black: colors.black,
     },
   },
-  plugins: [glowPlugin],
+  plugins: [glowPlugin, firefoxSelector],
 };

--- a/tailwind_plugins_src/firefoxSelector.js
+++ b/tailwind_plugins_src/firefoxSelector.js
@@ -1,0 +1,15 @@
+const plugin = require("tailwindcss/plugin");
+
+module.exports = plugin(({ addVariant, e, postcss }) => {
+  addVariant("firefox", ({ container, separator }) => {
+    const isFirefoxRule = postcss.atRule({
+      name: "-moz-document",
+      params: "url-prefix()",
+    });
+    isFirefoxRule.append(container.nodes);
+    container.append(isFirefoxRule);
+    isFirefoxRule.walkRules((rule) => {
+      rule.selector = `.${e(`firefox${separator}${rule.selector.slice(1)}`)}`;
+    });
+  });
+});


### PR DESCRIPTION
Both issues were fixed by creating a firefox selector for tailwind css that detects when firefox is being used. The code for this was quite literally copied and pasted from [goated link](https://braydoncoyer.dev/blog/build-a-glassmorphic-navbar-with-tailwindcss-backdrop-filter-and-backdrop-blur).